### PR TITLE
anonymous blade components

### DIFF
--- a/frameworks/laravel.md
+++ b/frameworks/laravel.md
@@ -66,6 +66,48 @@ class ImprintController {
     }
 }
 ```
+
+## Blade
+
+### Anonymous components
+Use anonymous Blade components if no data needs to be queried from the database. Basic varaible imputs may be solved using the laravel magic.
+Component classes only transfering the data from the constructor to public properties are 
+
+**BAD**
+```php
+class Card extends Component {
+    //...
+    public $title;
+    
+    public function __construct($title = null)
+    {
+        $this->title = $title;
+    }
+    //...
+}
+```
+```blade
+<x-card :title="$card->title" :text="$card->text"/>
+
+//
+
+<div>
+   <h4>{{$title}}</h4>
+   <p>{{$text}}</p>
+</div>
+```
+**GOOD**
+```blade
+<x-card :title="$card->title" :text="$card->text"/>
+
+//
+
+<div>
+   <h4>{{$title}}</h4>
+   <p>{{$text}}</p>
+</div>
+```
+
 ## Other best practies
 
 Follow other generally accepted [best practices for laravel](https://github.com/alexeymezenin/laravel-best-practices).


### PR DESCRIPTION
Yesterday we've talked about anonymous blade components. And imho they are great, as it reduces some (redundant) overhead. 

But looking at the official Laravel documentation for blade and  [passing data to blade components](https://laravel.com/docs/8.x/blade#passing-data-to-components). It states:
>You should define the component's required data in its class constructor.

As seen in the example, it's not actually necessary and personally I definitely prefer a way without an extra class. But would we be going against a documented Laravel convention/rule with this?

